### PR TITLE
Better word wrap

### DIFF
--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -71,7 +71,7 @@ module Colsole
 
   # Returns [width, height] of terminal when detected, or a default
   # value otherwise.
-  def detect_terminal_size(default=80)
+  def detect_terminal_size(default=[80,30])
     if (ENV['COLUMNS'] =~ /^\d+$/) && (ENV['LINES'] =~ /^\d+$/)
       [ENV['COLUMNS'].to_i, ENV['LINES'].to_i]
     elsif (RUBY_PLATFORM =~ /java/ || (!STDIN.tty? && ENV['TERM'])) && command_exist?('tput')
@@ -83,10 +83,16 @@ module Colsole
     end
   end
 
+  # Returns terminal width with re-asking
+  def terminal_width
+    @terminal_width ||= detect_terminal_size[0]
+  end
+
   # Converts a long string to be wrapped keeping words in tact.
   # If the string starts with one or more spaces, they will be 
   # preserved in all subsequent lines (i.e., remain indented).
-  def word_wrap(text, length=78)
+  def word_wrap(text, length=nil)
+    length ||= terminal_width
     lead = text[/^\s*/]
     text.strip!
     length -= lead.length

--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -88,8 +88,11 @@ module Colsole
   # preserved in all subsequent lines (i.e., remain indented).
   def word_wrap(text, length=78)
     lead = text[/^\s*/]
-    length -= lead.size
-    text.gsub(/(.{1,#{length}}\n?)(\s+|\Z)/, "\\1\n#{lead}").rstrip
+    text.strip!
+    length -= lead.length
+    text.split("\n").collect! do |line|
+      line.length > length ? line.gsub(/(.{1,#{length}})(\s+|$)/, "#{lead}\\1\n").rstrip : "#{lead}#{line}"
+    end * "\n"
   end
 
   # Parses and returns a color-flagged string.

--- a/test/colsole_test.rb
+++ b/test/colsole_test.rb
@@ -40,13 +40,13 @@ class ColsoleTest < Minitest::Test
 
   def test_word_wrap
     str = "   The winding path to peace is always a worthy one, regardless of how many turns it takes."
-    out = "   The winding path to peace is\n   always a worthy one, regardless of\n   how many turns it takes."
+    out = "   The winding path to peace is always a\n   worthy one, regardless of how many\n   turns it takes."
     assert_equal out, word_wrap(str, 40)
   end
 
   def test_word_wrap_newline
     str = "   hello world\n\none\ntwo"
-    out = "   hello\n   world\n\n   one\n   two"
+    out = "   hello\n   world\n   \n   one\n   two"
     assert_equal out, word_wrap(str, 12)
   end
 


### PR DESCRIPTION
The word_wrap method did not handle the first line nicely (it was always a little short).
The new implementation is borrowing code from the [ActionView Text Helpers][1], and the noticeable changes are:

- First line of indented word wrapping is now handled properly
- The length parameter of the `word_wrap` method now defaults to the terminal width instead of  the arbitrary 78

[1]: https://github.com/rails/rails/blob/0e50b7bdf4c0f789db37e22dc45c52b082f674b4/actionview/lib/action_view/helpers/text_helper.rb#L240