### PR TITLE
Fix TTY detection and allow TTY force

### DIFF
--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -59,12 +59,12 @@ module Colsole
 
   # Returns true if stdout is interactive terminal
   def out_terminal?
-    STDOUT.tty?
+    $stdout.tty? or ENV['TTY']
   end
 
   # Returns true if stderr is interactive terminal
   def err_terminal?
-    STDERR.tty?
+    $stderr.tty? or ENV['TTY']
   end
 
   # Determines if a shell command exists.

--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -59,12 +59,12 @@ module Colsole
 
   # Returns true if stdout is interactive terminal
   def out_terminal?
-    $stdout.tty? or ENV['TTY']
+    ENV['TTY'] == 'on' ? true : ENV['TTY'] == 'off' ? false : $stdout.tty?
   end
 
   # Returns true if stderr is interactive terminal
   def err_terminal?
-    $stderr.tty? or ENV['TTY']
+    ENV['TTY'] == 'on' ? true : ENV['TTY'] == 'off' ? false : $stderr.tty?
   end
 
   # Determines if a shell command exists.

--- a/spec/colsole/colsole_spec.rb
+++ b/spec/colsole/colsole_spec.rb
@@ -58,6 +58,36 @@ describe Colsole do
     end
   end
 
+  describe "#terminal?" do
+    context "when TTY environment is on" do
+      it "always returns true" do
+        prev_value = ENV['TTY']
+        ENV['TTY'] = 'on'
+        expect(terminal?).to be true
+        ENV['TTY'] = prev_value
+      end
+    end
+
+    context "when TTY environment is off" do
+      it "always returns false" do
+        prev_value = ENV['TTY']
+        ENV['TTY'] = 'off'
+        expect(terminal?).to be false
+        ENV['TTY'] = prev_value
+      end
+    end
+
+    context "when TTY environment is unset" do
+      it "refers to the stream" do
+        prev_value = ENV['TTY']
+        ENV['TTY'] = nil
+        expect($stdout).to receive(:tty?).and_return true
+        expect(terminal?).to be true
+        ENV['TTY'] = prev_value
+      end
+    end
+  end
+
   describe "#command_exist?" do
     context "with an existing command" do
       it "returns true" do
@@ -175,7 +205,7 @@ describe Colsole do
     end
   end
 
-  describe "#termina_width" do
+  describe "#terminal_width" do
     it "returns the first element of #detect_terminal_size" do
       expect(terminal_width).to eq detect_terminal_size[0]
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'rubygems'
 require 'bundler'
 Bundler.require :default, :development
 
+ENV['TTY'] = 'on'
+
 system 'mkdir tmp' unless Dir.exist? 'tmp'
 
 include Colsole


### PR DESCRIPTION
Read TTY state from `$stdout`  instead of `STDOUT`.
Also, add the ability to force TTY on or off by setting the environment `TTY` to `on` or `off`.

This is helpful when running tests of things that output colorful output since it allows forcing the colsole behavior to be the same in all scenarios.