### PR TITLE
Fix say in non tty when ending with a space

### DIFF
--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -26,7 +26,7 @@ module Colsole
     if terminal? and (last == ' ' or last == '\t')
       print colorize(text, force_color)
     else
-      print colorize("#{text}\n", force_color)
+      print colorize("#{text.rstrip}\n", force_color)
     end
   end
 

--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -23,7 +23,7 @@ module Colsole
   # Space terminated strings will leave the cursor at the same line.
   def say(text, force_color=false) 
     last = text[-1, 1]
-    if last == ' ' or last == '\t'
+    if terminal? and (last == ' ' or last == '\t')
       print colorize(text, force_color)
     else
       print colorize("#{text}\n", force_color)
@@ -39,7 +39,7 @@ module Colsole
   # Erase the current output line, and say a new string.
   # This should be used after a space terminated say().
   def resay(text, force_color=false) 
-    terminal? and text = "\033[2K\r#{text}"
+    text = "\033[2K\r#{text}" if terminal?
     say text, force_color
   end
 

--- a/spec/colsole/colsole_spec.rb
+++ b/spec/colsole/colsole_spec.rb
@@ -12,7 +12,7 @@ describe Colsole do
       end
 
       context "when not in tty" do
-        before { @old_value = ENV['TTY']; ENV['TTY'] = 'off'}
+        before { @old_value = ENV['TTY']; ENV['TTY'] = 'off' }
         after  { ENV['TTY'] = @old_value }
 
         it "adds newline as if the text did not end with a space" do

--- a/spec/colsole/colsole_spec.rb
+++ b/spec/colsole/colsole_spec.rb
@@ -10,6 +10,15 @@ describe Colsole do
       it "stays on the same line" do
         expect{say 'hello '}.to output('hello ').to_stdout 
       end
+
+      context "when not in tty" do
+        before { @old_value = ENV['TTY']; ENV['TTY'] = 'off'}
+        after  { ENV['TTY'] = @old_value }
+
+        it "adds newline as if the text did not end with a space" do
+          expect{say 'hello '}.to output("hello\n").to_stdout 
+        end        
+      end
     end
 
     context "with color markers" do


### PR DESCRIPTION
When using `say "something that ends with space "`, then the next `resay` will overwrite this line.
When sending the output to file, this output looks very weird and unusable.

This PR makes the `say` function have the same output in non tty, regardless of trailing space.