### PR TITLE
Fix say rstrip

### DIFF
--- a/lib/colsole.rb
+++ b/lib/colsole.rb
@@ -26,7 +26,7 @@ module Colsole
     if terminal? and (last == ' ' or last == '\t')
       print colorize(text, force_color)
     else
-      print colorize("#{text.rstrip}\n", force_color)
+      print colorize("#{text}\n", force_color)
     end
   end
 

--- a/spec/colsole/colsole_spec.rb
+++ b/spec/colsole/colsole_spec.rb
@@ -16,7 +16,7 @@ describe Colsole do
         after  { ENV['TTY'] = @old_value }
 
         it "adds newline as if the text did not end with a space" do
-          expect{say 'hello '}.to output("hello\n").to_stdout 
+          expect{say 'hello '}.to output("hello \n").to_stdout 
         end        
       end
     end


### PR DESCRIPTION
Have `rstrip` in the `say` method was a terrible idea. It destroys things like `say "hello\n\n"`.

Ctrl+Z.